### PR TITLE
Modifies developer db link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ With the API Program, Deutsche Bank makes a large amount of customer data access
 The technical cornerstone of this is the Developer Portal. With this repo, we would like to make it a little easier for interested developers 
 to access our APIs, documentation and the sandbox.
 
-Visit our Developer Portal at [developer.db.com](developer.db.com) to find out more.
+Visit our Developer Portal at [developer.db.com](https://developer.db.com) to find out more.
 
 ## Content
 


### PR DESCRIPTION
The current README markdown link for our API program link redirects to a relative link, I have updated with full address for developer.db.com so that it now takes visitors to the correct link.